### PR TITLE
check for note == nil to avoid error

### DIFF
--- a/lib/Engine_MxSynths.sc
+++ b/lib/Engine_MxSynths.sc
@@ -558,7 +558,7 @@ Engine_MxSynths : CroneEngine {
 			arg note;
 			// ("note off: "++note).postln;		
 			// remove it it hasn't already been removed	and synth gone	
-			if ((mxVoices.at(note).isRunning==false)&&(mxVoicesOn.at(note)==nil),{},{
+			if ((mxVoices.at(note) == nil) || ((mxVoices.at(note).isRunning==false)&&(mxVoicesOn.at(note)==nil)),{},{
 				// if monophonic, remove all the other sounds
 				if (mxParameters.at("monophonic")>0,{
 					fnNoteOffMono.(note);


### PR DESCRIPTION
I noticed that if you really keyboard-smash you can get SuperCollider to give you errors complaining that `nil` doesn't understand `isRunning`.  This check should avoid those errors.